### PR TITLE
Draft implementation of pooling layers

### DIFF
--- a/python/mlx/nn/layers/__init__.py
+++ b/python/mlx/nn/layers/__init__.py
@@ -37,6 +37,7 @@ from mlx.nn.layers.dropout import Dropout, Dropout2d
 from mlx.nn.layers.embedding import Embedding
 from mlx.nn.layers.linear import Linear
 from mlx.nn.layers.normalization import BatchNorm, GroupNorm, LayerNorm, RMSNorm
+from mlx.nn.layers.pooling import MaxPooling2d
 from mlx.nn.layers.positional_encoding import ALiBi, RoPE, SinusoidalPositionalEncoding
 from mlx.nn.layers.quantized import QuantizedLinear
 from mlx.nn.layers.transformer import (

--- a/python/mlx/nn/layers/pooling.py
+++ b/python/mlx/nn/layers/pooling.py
@@ -1,0 +1,42 @@
+# Copyright © 2023 Apple Inc.
+
+
+import mlx.core as mx
+from mlx.nn.layers.base import Module
+
+
+class MaxPooling2d(Module):
+    def __init__(self, kernel_size: int, stride: int, padding: int):
+        super().__init__()
+        self.kernel_size = kernel_size
+        self.stride = stride
+        self.padding = padding
+
+    def __call__(self, a):
+        # For the sake of simplicity, assumes that a is two dimensional.
+        a = mx.pad(a, self.padding)
+        # Compute sliding windows by creating a strided view
+        output_shape = (
+            (a.shape[0] - self.kernel_size) // self.stride + 1,
+            (a.shape[1] - self.kernel_size) // self.stride + 1,
+        )
+        windows_shape = (
+            output_shape[0],
+            output_shape[1],
+            self.kernel_size,
+            self.kernel_size,
+        )
+        windows_strides = (
+            self.stride * a.strides[0],
+            self.stride * a.strides[1],
+            a.strides[0],
+            a.strides[1],
+        )
+        windows = mx.as_strided(a, windows_shape, windows_strides)
+        # Set reduction axes
+        reduction_axes = (2, 3)
+        # For demo purposes
+        print(a)
+        print(windows)
+        # Reduce over all windows
+        return mx.max(windows, reduction_axes)

--- a/python/pooling_demo.py
+++ b/python/pooling_demo.py
@@ -1,0 +1,9 @@
+import mlx.core as mx
+from mlx.nn.layers import MaxPooling2d
+
+a = mx.arange(16).reshape((4, 4))
+pool_no_padding = MaxPooling2d(kernel_size=2, stride=2, padding=0)
+print(pool_no_padding(a))
+print("--")
+pool_with_padding = MaxPooling2d(kernel_size=2, stride=2, padding=1)
+print(pool_with_padding(a))

--- a/python/src/array.cpp
+++ b/python/src/array.cpp
@@ -531,6 +531,14 @@ void init_array(py::module_& m) {
             list(int): A list containing the sizes of each dimension.
         )pbdoc")
       .def_property_readonly(
+          "strides",
+          [](const array& a) { return a.strides(); },
+          R"pbdoc(
+          The strides of the array as a Python list.
+          Returns:
+            list(int): A list containing the strides.
+        )pbdoc")
+      .def_property_readonly(
           "dtype",
           &array::dtype,
           R"pbdoc(


### PR DESCRIPTION
## Proposed changes

Goal: Implement MaxPooling and AveragePooling.

MaxPooling and AveragePooling layers were requested in [this issue](https://github.com/ml-explore/mlx/issues/25). In this draft PR, I propose implementing the requested pooling operations by firstly computing sliding windows and subsequently reducing them. More precisely, we can use ``as_strided`` to compute pooling sliding windows. Then, we can simply reduce over appropriate axes to implement the desired pooling operation.

To demonstrate this approach and gain feedback, I implemented a special case of  `MaxPooling2d`, assuming the input is a matrix. Below is a demonstration, which can be reproduced by running ``python/pooling_demo.py``.

**no padding**
```
padded input: 
array([[0, 1, 2, 3],
       [4, 5, 6, 7],
       [8, 9, 10, 11],
       [12, 13, 14, 15]], dtype=int32)
windows: 
array([[[[0, 1],
         [4, 5]],
        [[2, 3],
         [6, 7]]],
       [[[8, 9],
         [12, 13]],
        [[10, 11],
         [14, 15]]]], dtype=int32)
output: 
array([[5, 7],
       [13, 15]], dtype=int32)
```

**zero padding of 1**
```
padded input: 
array([[0, 0, 0, 0, 0, 0],
       [0, 0, 1, 2, 3, 0],
       [0, 4, 5, 6, 7, 0],
       [0, 8, 9, 10, 11, 0],
       [0, 12, 13, 14, 15, 0],
       [0, 0, 0, 0, 0, 0]], dtype=int32)
windows: 
array([[[[0, 0],
         [0, 0]],
        [[0, 0],
         [1, 2]],
        [[0, 0],
         [3, 0]]],
       [[[0, 4],
         [0, 8]],
        [[5, 6],
         [9, 10]],
        [[7, 0],
         [11, 0]]],
       [[[0, 12],
         [0, 0]],
        [[13, 14],
         [0, 0]],
        [[15, 0],
         [0, 0]]]], dtype=int32)
output: 
array([[0, 2, 3],
       [8, 10, 11],
       [12, 14, 15]], dtype=int32)
```

Of course, this is not a complete implementation. I would like to get some feedback on this first step. If we are happy with this approach, I can extend this to a complete implementation.


## Checklist

Put an `x` in the boxes that apply.

- [ ] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
